### PR TITLE
PCHR-1385: Remove ARRAY_FILTER_USE_BOTH usage for php 5.5 compatibility

### DIFF
--- a/civihr_default_theme/template.php
+++ b/civihr_default_theme/template.php
@@ -296,9 +296,13 @@ function civihr_default_theme_form_element_label($variables) {
  * @return array
  */
 function bootstrapable_fields($fields_structure) {
-  return array_filter($fields_structure, function($value, $key) {
-    return substr($key, 0, 1) <> '#' && !in_array($value['#type'], ['hidden']);
-  }, ARRAY_FILTER_USE_BOTH);
+  $fields = $fields_structure;
+  foreach($fields as $key => $value)  {
+    if (!(substr($key, 0, 1) <> '#' && !in_array($value['#type'], ['hidden'])))  {
+      unset($fields[$key]);
+    }
+  }
+  return $fields;
 }
 
 /**


### PR DESCRIPTION
## Problem

the **array_filter** core php method was used with **ARRAY_FILTER_USE_BOTH** option which is introduced in PHP 5.6.0 , which  cause the minimum PHP  version to run the Civihr/SPP to be 5.6.0 too . 

But as specified here https://wiki.civicrm.org/confluence/display/CRMDOC/CiviCRM+PHP+Requirements , the minimum version should be 5.5 .
## Solution

I replaced the array_filter with ARRAY_FILTER_USE_BOTH by **foreach** implementation.
