### PR TITLE
PCHR-1520: Add (HR resource types) link to gear menu and fix permissions

### DIFF
--- a/civihr_default_theme/templates/page/page.tpl.php
+++ b/civihr_default_theme/templates/page/page.tpl.php
@@ -15,8 +15,31 @@
 
   $admin_link = l(t('CiviHR admin'), 'civicrm', array('html' => true));
   $ssp_link = l(t('CiviHR SSP'), 'dashboard', array('html' => true));
-  $documents_link = l(t('Manage documents'), 'admin/content', array('html' => true));
-  $users_link = l(t('Manage users'), 'admin/people', array('html' => true));
+
+  $resourceTypeVocabularyID = taxonomy_vocabulary_machine_name_load('hr_resource_type')->vid;
+  $mapGearLinks = [
+    [
+      'permissions' => ["access content overview"],
+      'link' => l(t('Manage documents'), 'admin/content', array('html' => true)),
+    ],
+    [
+      'permissions' => ["administer users", "access users overview"],
+      'link' => l(t('Manage users'), 'admin/people', array('html' => true)),
+    ],
+    [
+      'permissions' => ["edit terms in {$resourceTypeVocabularyID}"],
+      'link' => l(t('HR resource types'), 'hr-resource-types-list', array('html' => true))
+    ],
+  ];
+  $gearLinks = "";
+  foreach($mapGearLinks as $link) {
+    foreach ($link['permissions'] as $permission) {
+      if (user_access($permission)) {
+        $gearLinks .= "<li>{$link['link']}</li>";
+        break;
+      }
+    }
+  }
 ?>
 
 <div id="outer-wrapper">
@@ -64,12 +87,11 @@
       </ul>
     </div>
     <?php } ?>
-    <?php if (user_access("administer users") && user_access("administer nodes") ) { ?>
+    <?php if (!empty($gearLinks)) { ?>
     <div class="chr_header__settings-menu">
       <i class="fa fa-cog" aria-hidden="true"></i>
       <ul class="chr_header__sub-menu">
-        <li><?php print $documents_link; ?></li>
-        <li><?php print $users_link; ?></li>
+        <?php print $gearLinks ?>
       </ul>
     </div>
     <?php } ?>


### PR DESCRIPTION
This add a new link (HR resource types) to gear menu for the view in this PR https://github.com/compucorp/civihr-employee-portal/pull/210

![selection_032](https://cloud.githubusercontent.com/assets/6275540/18948535/616bf0f4-862f-11e6-9057-94abb18161c3.png)

also I fixed the permissions checking so the gear menu appear with the allowed links if the user has any of the following permissions ([access content overview] => for manage documents , [administer users or access users overview ] => for manage users , [edit terms in hr_resource_type] => for HR resource Types  ) 
