### PR TITLE
PCHR-1650: Hide Civihr admin

### DIFF
--- a/civihr_default_theme/templates/page/page.tpl.php
+++ b/civihr_default_theme/templates/page/page.tpl.php
@@ -29,7 +29,9 @@
           <span class="chr_brand__icon icon-logo"></span>
           <span><?php print t("Home"); ?></span>
         <ul class="chr_header__sub-menu">
-          <li><?php print $admin_link; ?></li>
+          <?php if (user_access("access CiviCRM")) { ?>
+            <li><?php print $admin_link; ?></li>
+          <?php } ?>
           <li><?php print $ssp_link; ?></li>
         </ul>
       </div>


### PR DESCRIPTION
**Requirement**
When you don't have access to Civicrm don't show the "Civihr Admin" option in the logo drop down.

**Fix**
Checking if user has `access CiviCRM` permission before showing "Civihr Admin"
