### PR TITLE
PCHR-1589: change civihr admin to point for T&A dashboard

### DIFF
--- a/civihr_default_theme/templates/page/page.tpl.php
+++ b/civihr_default_theme/templates/page/page.tpl.php
@@ -13,7 +13,7 @@
  * both to stick at the top of the page and to be as tall as the content (necessary because of the Drupal toolbar)
  */
 
-  $admin_link = l(t('CiviHR admin'), 'civicrm', array('html' => true));
+  $admin_link = l(t('CiviHR admin'), 'civicrm/tasksassignments/dashboard#/tasks', array('html' => true));
   $ssp_link = l(t('CiviHR SSP'), 'dashboard', array('html' => true));
 
   $resourceTypeVocabularyID = taxonomy_vocabulary_machine_name_load('hr_resource_type')->vid;


### PR DESCRIPTION
"CiviHR admin" link in SSP

![_thumb_30514](https://cloud.githubusercontent.com/assets/6275540/19701550/cd722eca-9af3-11e6-80c8-d35d3efc544d.png)

should point to T&A dashboard not to civicrm dashboard
