### PR TITLE
PCHR-1710: Fixing CiviHR admin URL in drop-down menu

### DIFF
--- a/civihr_default_theme/templates/page/page.tpl.php
+++ b/civihr_default_theme/templates/page/page.tpl.php
@@ -13,7 +13,7 @@
  * both to stick at the top of the page and to be as tall as the content (necessary because of the Drupal toolbar)
  */
 
-  $admin_link = l(t('CiviHR admin'), 'civicrm/tasksassignments/dashboard#/tasks', array('html' => true));
+  $admin_link = l(t('CiviHR admin'), 'civicrm/tasksassignments/dashboard', ['fragment' => '/tasks']);
   $ssp_link = l(t('CiviHR SSP'), 'dashboard', array('html' => true));
 
   $resourceTypeVocabularyID = taxonomy_vocabulary_machine_name_load('hr_resource_type')->vid;


### PR DESCRIPTION
Drupal [l](https://api.drupal.org/api/drupal/includes%21common.inc/function/l/7.x) function will escape any special characters in the link automatically which was causing issues when clicking on the link . So here I just changed how the link get generated by passing the part after the hash (#) to  [l](https://api.drupal.org/api/drupal/includes%21common.inc/function/l/7.x) function  fragment attribute .