### PR TITLE
PCHR-1953: Altered Manager Leave menu to attach markup for displaying number of pending leave request.

### DIFF
--- a/civihr_default_theme/template.php
+++ b/civihr_default_theme/template.php
@@ -418,13 +418,22 @@ function civihr_default_theme_menu_link__dropdown($variables) {
   /* End - Code Added */
   $output = l($element['#title'], $element['#href'], $element['#localized_options']);
 
-  // Adding markup from template that holds number of pending leave request using
-  // angularjs app to display with Manager Leave menu.
+  // Alter Manager Leave menu to show number of pending leave requests.
   if ($element['#title'] === 'Manager Leave') {
-    $markup = civihr_leave_absences_pending_leave_request_get_markup();
-    $output .= $markup;
+    _get_pending_leave_request_markup($output);
   }
 
   return '<li' . drupal_attributes($element['#attributes']) . '>' . $output . $sub_menu . "</li>\n";
 }
 
+/**
+ * Adding markup from template that holds number of pending leave request
+ * to display with Manager Leave menu.
+ *
+ * @param String
+ *    Menu item link.
+ */
+function _get_pending_leave_request_markup(&$output) {
+  $markup = civihr_leave_absences_get_markup('pending-leave-request');
+  $output .= $markup;
+}

--- a/civihr_default_theme/template.php
+++ b/civihr_default_theme/template.php
@@ -417,6 +417,14 @@ function civihr_default_theme_menu_link__dropdown($variables) {
   _hide_menu_items($element);
   /* End - Code Added */
   $output = l($element['#title'], $element['#href'], $element['#localized_options']);
+
+  // Adding markup from template that holds number of pending leave request using
+  // angularjs app to display with Manager Leave menu.
+  if ($element['#title'] === 'Manager Leave') {
+    $markup = civihr_leave_absences_pending_leave_request_get_markup();
+    $output .= $markup;
+  }
+
   return '<li' . drupal_attributes($element['#attributes']) . '>' . $output . $sub_menu . "</li>\n";
 }
 


### PR DESCRIPTION
**Task**
Add custom markup for "Manager Leave" menu item that would act as placeholder to angular js files to display number of pending leave requests.

**Solution**
Added function to load the angular js app and custom template to show number of pending leave requests from civihr_leave_absences module ( https://github.com/compucorp/civihr-employee-portal/pull/270 ) and alter the Manager Leave menu item to attach markup.
