### PR TITLE
PCHR-2159: Add Pull Request Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Overview
+_A brief description of the pull request. Try to keep it non-technical. Please mark your pull request with the appropriate [label(s)](../CONTRIBUTING.md#label-types)_
+
+## Before
+_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
+
+## After
+_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
+
+## Technical Details
+_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_
+
+## Comments
+_Anything else you would like the reviewer to note_
+
+---
+
+- [ ] Tests Pass

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+## Contributing
+
+CiviHR is an open-source project and we welcome new contributions from the community.
+
+## Label Types
+We use the following label types for issues and pull requests:
+
+- Bug: Fixes an error on an existing feature.
+- Enhancement: Improves an existing feature without changing how it behaves (examples: performance improvement, code refactoring, adding new tests).
+- New Feature: Adds a new feature to the system. It can be a completely new feature (like a new extension) or an addition to an existing feature.


### PR DESCRIPTION
## Overview

Adds a pull request template.

## Before

Each creator of a pull request defined their own structure for the description.

## After

This template will be used as a suggested format for the description.

## Comments

To see what the PR template looks like now check [here](https://github.com/civicrm/civihr/blob/PCHR-2159-pull-request-template/.github/PULL_REQUEST_TEMPLATE.md)

---

- [x] Tests Pass