### PR TITLE
PCHR-2213: Add user guide link to ssp pages

### DIFF
--- a/civihr_default_theme/templates/page/page.tpl.php
+++ b/civihr_default_theme/templates/page/page.tpl.php
@@ -151,6 +151,7 @@
         Powered by CiviHR <?php print get_civihr_version(); ?>.
         CiviHR is openly available under the <a href="http://www.gnu.org/licenses/agpl-3.0.html ">GNU AGPL License</a>.
         <br />
+        <a target="_blank" href="http://civihr-documentation.readthedocs.io/en/latest/">User Guide</a>&nbsp;
         <a target="_blank" href="https://github.com/civicrm/civihr">Download CiviHR</a>&nbsp;
         <a target="_blank" href="https://civihr.atlassian.net/wiki/display/CIV/Welcome ">View Wiki page</a>&nbsp;
         <a target="_blank" href="https://civihr.org">Project website</a>


### PR DESCRIPTION
## Overview
Add "User guide" link to ssp pages which links to "http://civihr-documentation.readthedocs.io/en/latest/"

## Before
<img width="1175" alt="screen shot 2017-05-29 at 6 58 30 pm" src="https://cloud.githubusercontent.com/assets/6307362/26551170/e18f9ab2-44a0-11e7-873f-d48796a6b8d3.png">

## After
<img width="1233" alt="screen shot 2017-05-29 at 6 56 56 pm" src="https://cloud.githubusercontent.com/assets/6307362/26551108/a2f6e6fc-44a0-11e7-9aec-e6ca240528eb.png">
