### PR TITLE
PCHR-2358: Add user guide link + modified footer in ssp pages

### DIFF
--- a/civihr_default_theme/templates/page/page.tpl.php
+++ b/civihr_default_theme/templates/page/page.tpl.php
@@ -92,8 +92,8 @@
       </div>
       <ul class="chr_header__sub-menu">
         <li><?php print $edit_account; ?></li>
-        <li><?php print $logout_link; ?></li>
         <li><?php print $user_guide_link; ?></li>
+        <li><?php print $logout_link; ?></li>
       </ul>
     </div>
     <?php } ?>
@@ -150,7 +150,7 @@
     <div class="container">
       <div class="text-center">
         Powered by CiviHR <?php print get_civihr_version(); ?>.
-        CiviHR is openly available under the <a href="http://www.gnu.org/licenses/agpl-3.0.html">GNU AGPL License</a> and can be downloaded from the onkeyup=""<a target="_blank" href="https://civihr.org">Project website</a>&nbsp;.
+        CiviHR is openly available under the <a target="_blank" href="http://www.gnu.org/licenses/agpl-3.0.html">GNU AGPL License</a> and can be downloaded from the <a target="_blank" href="https://civihr.org">Project website</a>&nbsp;.
         <div class="footer-logo">
           <i class="icon-logo-full"></i>
         </div>

--- a/civihr_default_theme/templates/page/page.tpl.php
+++ b/civihr_default_theme/templates/page/page.tpl.php
@@ -93,6 +93,7 @@
       <ul class="chr_header__sub-menu">
         <li><?php print $edit_account; ?></li>
         <li><?php print $logout_link; ?></li>
+        <li><?php print $user_guide_link; ?></li>
       </ul>
     </div>
     <?php } ?>
@@ -149,12 +150,7 @@
     <div class="container">
       <div class="text-center">
         Powered by CiviHR <?php print get_civihr_version(); ?>.
-        CiviHR is openly available under the <a href="http://www.gnu.org/licenses/agpl-3.0.html ">GNU AGPL License</a>.
-        <br />
-        <a target="_blank" href="http://civihr-documentation.readthedocs.io/en/latest/">User Guide</a>&nbsp;
-        <a target="_blank" href="https://github.com/civicrm/civihr">Download CiviHR</a>&nbsp;
-        <a target="_blank" href="https://civihr.atlassian.net/wiki/display/CIV/Welcome ">View Wiki page</a>&nbsp;
-        <a target="_blank" href="https://civihr.org">Project website</a>
+        CiviHR is openly available under the <a href="http://www.gnu.org/licenses/agpl-3.0.html">GNU AGPL License</a> and can be downloaded from the onkeyup=""<a target="_blank" href="https://civihr.org">Project website</a>&nbsp;.
         <div class="footer-logo">
           <i class="icon-logo-full"></i>
         </div>


### PR DESCRIPTION
## Overview
- A new sub-menu in account menu in SSP. 
- Modify footer for SSP pages

## After
Displays more information in footer
![screen shot 2017-07-12 at 8 02 02 pm](https://user-images.githubusercontent.com/6307362/28122174-1e2dbe22-673d-11e7-87eb-804082be6505.png)

## After
Displays only required information in footer.
![screen shot 2017-07-12 at 7 51 23 pm](https://user-images.githubusercontent.com/6307362/28121675-9437b8ae-673b-11e7-8d69-ad28156a55d0.png)

## Technical Details:
1. Modify "civihr_default_theme/templates/page/page.tpl.php" for sub menu
```html
<ul class="chr_header__sub-menu">
   ...
   <li><?php print $user_guide_link; ?></li>
</ul>
```
2. Modify "civihr_default_theme/templates/page/page.tpl.php" file for footer.
```html
<div class="text-center">
    Powered by CiviHR <?php print get_civihr_version(); ?>.
    CiviHR is openly available under the <a href="http://www.gnu.org/licenses/agpl-3.0.html">GNU 
    AGPL License</a> and can be downloaded from
    <a target="_blank" href="https://civihr.org">Project website</a>&nbsp;.
    <div class="footer-logo">
    <i class="icon-logo-full"></i>
</div>
```