### PR TITLE
PCHR-2387: Update Attachment List Fieldset Template

### DIFF
--- a/civihr_default_theme/templates/view/views-fieldsets-fieldset--hr-documents--hr-resources.tpl.php
+++ b/civihr_default_theme/templates/view/views-fieldsets-fieldset--hr-documents--hr-resources.tpl.php
@@ -1,20 +1,14 @@
 <div class="chr_hr-resource__attachments col-sm-12">
-  <<?php print $tag; ?> class="<?php print $classes; ?>"<?php print $attributes; ?>>
+  <fieldset class="<?php print $classes; ?>"<?php print $attributes; ?>>
 
-    <?php if ($legend_tag): ?>
-      <<?php print $legend_tag; ?>>
-        <span class="fieldset-legend"><?php print $legend; ?></span>
-      </<?php print $legend_tag; ?>>
-      <div class="fieldset-wrapper">
-    <?php endif; ?>
+    <legend>
+      <span class="fieldset-legend"><?php print $legend; ?></span>
+    </legend>
 
-    <?php foreach ($fieldset_fields as $name => $field): ?>
-      <?php print @$field->separator . $field->wrapper_prefix . $field->label_html . $field->content . $field->wrapper_suffix; ?>
-    <?php endforeach; ?>
-
-    <?php if ($legend_tag): ?>
-      </div><?php /* .fieldset-wrapper */ ?>
-    <?php endif; ?>
-
-  </<?php print $tag; ?>>
+    <div class="fieldset-wrapper">
+      <?php foreach ($fieldset_fields as $name => $field): ?>
+        <?php print @$field->separator . $field->wrapper_prefix . $field->label_html . $field->content . $field->wrapper_suffix; ?>
+      <?php endforeach; ?>
+    </div>
+  </fieldset>
 </div>


### PR DESCRIPTION
## Overview
Staging and demo servers were showing HTML code on /hr-resources view on attachment list for each resource.

![image](https://user-images.githubusercontent.com/21999940/28209069-8328da18-6856-11e7-981c-3fb57a7ea01f.png)

## Before
The Fieldset template being used to show the list of attachments on hr-resources view is not compatible with version 7.x-2.1 of views_fieldsets module, which is the version being used on staging and demo servers.

## After
Updated the template so it works on both v1.2 and 2.1 of views_fieldsets.

![image](https://user-images.githubusercontent.com/21999940/28209153-e729ef0c-6856-11e7-90c8-9a0309176343.png)

## Comments
Existing installations of CiviHR will be updated to v2.1 of views_fieldset module.
New installations of CiviHR will use v2.1 of views_fieldsets module (see https://github.com/civicrm/civicrm-buildkit/pull/338).