### PR TITLE
PCHR-2474: Add new modules CSS and JS files to whitelist

### DIFF
--- a/civihr_default_theme/template.php
+++ b/civihr_default_theme/template.php
@@ -313,7 +313,8 @@ function civihr_default_theme_css_alter(&$css) {
       'sites/all/modules/civicrm/bower_components/font-awesome/css/font-awesome.css',
       'sites/all/modules/civihr-contrib-required/fancy_login/css/fancy_login.css',
       'sites/all/modules/civihr-contrib-required/radix_layouts/radix_layouts.css',
-      'sites/all/themes/civihr_employee_portal_theme/civihr_default_theme/assets/css/civihr_default_theme.style.css'
+      'sites/all/themes/civihr_employee_portal_theme/civihr_default_theme/assets/css/civihr_default_theme.style.css',
+      'sites/all/modules/civihr-signup/css/civihr-signup.css'
     ];
     foreach (array_keys($css) as $file) {
       $found = false;
@@ -401,7 +402,8 @@ function civihr_default_theme_js_alter(&$javascript) {
       'sites/all/modules/civihr-contrib-required/fancy_login/js/fancy_login.js',
       'sites/all/themes/civihr_employee_portal_theme/civihr_default_theme/assets/js/radix.modal.js',
       'sites/all/modules/civicrm/packages/jquery/plugins/jquery.blockUI.min.js',
-      'https://sdk.yoti.com/clients/browser.js'
+      'https://sdk.yoti.com/clients/browser.js',
+      'sites/all/modules/civihr-signup/js/civihr-signup.js'
     ];
     foreach (array_keys($javascript) as $file) {
       $found = false;


### PR DESCRIPTION
## Overview
With the new [civihr signup](https://github.com/compucorp/civihr-signup) module some CSS and JS files are required whenever this module is enabled. There is a whitelist of CSS and JS files in this theme and the signup block is not displaying correctly when they are not included.

## Before
The CSS and JS files for the CiviHR signup module were not included in the welcome page.

![image](https://user-images.githubusercontent.com/6374064/30426326-90cb287e-9943-11e7-894e-6dbda8dc9c54.png)

## After
The CSS and JS files for the CiviHR signup module are included in the welcome page.

![image](https://user-images.githubusercontent.com/6374064/30426352-a5775b3a-9943-11e7-96ff-411c41222049.png)

---

- [ ] Tests Pass
No tests in this repo