### PR TITLE
PCHR-2584: Do not gulp watch on gulp default task

### DIFF
--- a/civihr_default_theme/gulpfile.js
+++ b/civihr_default_theme/gulpfile.js
@@ -88,4 +88,4 @@ gulp.task('js-lint', function() {
 });
 
 // Default Task
-gulp.task('default', ['css', 'fonts', 'watch']);
+gulp.task('default', ['css', 'fonts']);


### PR DESCRIPTION
## Overview

This PR stops Gulp watching files on `gulp` command. This is made for several reasons:

- Sometimes developers are not sure when all Gulp tasks are completed;
- It is easy to accidentally leave Gulp watching files, checkout to another branch in another repository and sync wrong files as a result;
- Sometimes you would like to simply build distributive files and not watch them;
- There is no TDD process for CSS at the moment.