### PR TITLE
PCHR-2685: Add typekit js to whitelist

### DIFF
--- a/civihr_default_theme/template.php
+++ b/civihr_default_theme/template.php
@@ -403,7 +403,8 @@ function civihr_default_theme_js_alter(&$javascript) {
       'sites/all/themes/civihr_employee_portal_theme/civihr_default_theme/assets/js/radix.modal.js',
       'sites/all/modules/civicrm/packages/jquery/plugins/jquery.blockUI.min.js',
       'https://sdk.yoti.com/clients/browser.js',
-      'sites/all/modules/civihr-signup/js/civihr-signup.js'
+      'sites/all/modules/civihr-signup/js/civihr-signup.js',
+      'https://use.typekit.net/mhr5yod.js',
     ];
     foreach (array_keys($javascript) as $file) {
       $found = false;


### PR DESCRIPTION
## Overview
This ticket was originally to change the text (done in the [CiviHR Signup](https://github.com/compucorp/civihr-signup) module, but during testing Mike noticed that the font on the welcome page signup tab was not the same as the tab when seen on the rest of the site.

The problem was that the Javascript from Typekit to load the font was blocked by the CiviHR Default Theme Javascript whitelist

## Before

`use.typekit.net/mhr5yod.js` was blocked from the welcome-page, font was not loaded.

## After

`use.typekit.net/mhr5yod.js` was added to the whitelist, font displays as expected.

---

- [ ] Tests Pass
No tests in this repo
