### PR TITLE
PCHR-2852: Add Emergency Contact and Dependants blocks to page

### DIFF
--- a/civihr_default_theme/templates/page/page--hr-details.tpl.php
+++ b/civihr_default_theme/templates/page/page--hr-details.tpl.php
@@ -1,0 +1,22 @@
+<?php
+$includesDir = __DIR__ . '/../../includes/';
+$dependantsView = views_embed_view('emergency_contacts', 'dependant_emergency_contact');
+$emergencyContactsView = views_embed_view('emergency_contacts', 'non_dependant_emergency_contact');
+?>
+
+<div id="outer-wrapper">
+  <?php require_once $includesDir . 'header.inc'; ?>
+  <?php require_once __DIR__ . '/page_body.tpl.php'; ?>
+
+  <div class="container region region-content">
+    <h2>Emergency Contacts</h2>';
+    <?php print $emergencyContactsView; ?>
+  </div>
+
+  <div class="container region region-content">
+    <h2>Dependants</h2>
+    <?php print $dependantsView; ?>
+  </div>
+
+  <? require_once $includesDir . 'footer.inc' ?>
+</div>


### PR DESCRIPTION
## Overview

Emergency contact and dependants blocks should be shown after the my details block on the `/hr-details` page, but not on the `/dashboard` page.

## Before

The blocks are shown in both places as they were part of the my-details block template override (`civihr-employee-portal-my-details--block.tpl.php`)

#### Dashboard

![image](https://user-images.githubusercontent.com/6374064/32534257-ab0cfc6a-c44c-11e7-9766-50fbf79ffe7c.png)

## After

Emergency contact and dependants blocks appear on the `/hr-details` page, but not on `/dashboard`

#### Dashboard

![image](https://user-images.githubusercontent.com/6374064/32534327-02f1c424-c44d-11e7-96a1-b8154cd6c37e.png)

#### HR Details Page

There is no change to the appearance here, just the code producing it is different.

![image](https://user-images.githubusercontent.com/6374064/32509458-439b8c20-c3e5-11e7-92e5-0199627fae14.png)

## Technical Details

- I copied the template from page.tpl.php and modified it to add the new sections.

---

- [ ] Tests Pass
No tests