### PR TITLE
PCHR-2112: Datepicker Format Fix

### DIFF
--- a/civihr_default_theme/assets/js/civihr_default_theme.script.js
+++ b/civihr_default_theme/assets/js/civihr_default_theme.script.js
@@ -194,7 +194,7 @@
    * @return {Object}
    */
   function getDesktopCalendarValues (dateText) {
-    var fullDate = dateText.split('-');
+    var fullDate = dateText.split('/');
 
     return {
       date: parseInt(fullDate[0]),


### PR DESCRIPTION
## Overview

[This commit](https://github.com/compucorp/civihr-employee-portal-theme/commit/224b39fcddd1cd11326625f179a09a2572f79705#diff-96660d5004bc1bc824d5ac8ce01cdefeR258) changed the separator used in the date format for the calendar. However [another function](https://github.com/compucorp/civihr-employee-portal-theme/blob/224b39fcddd1cd11326625f179a09a2572f79705/civihr_default_theme/assets/js/civihr_default_theme.script.js#L197) in the same file expected the separator to still be `/`

## Before

The separators were mismatched and resulted in values from `getDesktopCalendarValues` being `NaN`. The user could not select the date and therefore could not progress to the next step in the onboarding form.

## After

The separators are matched, `getDesktopCalendarValues` returns the correct values and the user can complete the onboarding wizard.

---

- [ ] Tests Pass
