### PR TITLE
PCHR-2850: Add Delete button

### DIFF
--- a/civihr_default_theme/assets/js/civihr_default_theme.script.js
+++ b/civihr_default_theme/assets/js/civihr_default_theme.script.js
@@ -296,4 +296,8 @@
     $('#' + this.id + '-' + 'day').val(dateValues.date).trigger('change');
     $('#' + this.id + '-' + 'year').val(dateValues.year).trigger('change');
   }
+
+  Drupal.civihr_theme.deleteEmergencyContact =  function(id) {
+    CRM.api3('contact', 'deleteemergencycontact', {'id':id});
+  }
 })(jQuery);

--- a/civihr_default_theme/assets/js/civihr_default_theme.script.js
+++ b/civihr_default_theme/assets/js/civihr_default_theme.script.js
@@ -30,12 +30,13 @@
   Drupal.civihr_theme = Drupal.civihr_theme || {};
 
   /**
-   * Delete Emergency contacts
+   * Delete Emergency contacts and refresh the page
    *
    * @param {String} id
    */
-  Drupal.civihr_theme.deleteEmergencyContact = function (id) {
+  Drupal.civihr_theme.deleteEmergencyContactAndRefresh = function (id) {
     CRM.api3('contact', 'deleteemergencycontact', { 'id': id });
+    location.reload();
   };
 
   /**

--- a/civihr_default_theme/assets/js/civihr_default_theme.script.js
+++ b/civihr_default_theme/assets/js/civihr_default_theme.script.js
@@ -30,6 +30,15 @@
   Drupal.civihr_theme = Drupal.civihr_theme || {};
 
   /**
+   * Delete Emergency contacts
+   *
+   * @param {String} id
+   */
+  Drupal.civihr_theme.deleteEmergencyContact = function (id) {
+    CRM.api3('contact', 'deleteemergencycontact', { 'id': id });
+  };
+
+  /**
    * Do the stuff related to On boarding wizard
    */
   Drupal.civihr_theme.onBoardingWizard = function () {
@@ -295,9 +304,5 @@
     $('#' + this.id + '-' + 'month').val(dateValues.month).trigger('change');
     $('#' + this.id + '-' + 'day').val(dateValues.date).trigger('change');
     $('#' + this.id + '-' + 'year').val(dateValues.year).trigger('change');
-  }
-
-  Drupal.civihr_theme.deleteEmergencyContact =  function(id) {
-    CRM.api3('contact', 'deleteemergencycontact', {'id':id});
   }
 })(jQuery);

--- a/civihr_default_theme/templates/page/page--hr-details.tpl.php
+++ b/civihr_default_theme/templates/page/page--hr-details.tpl.php
@@ -9,7 +9,7 @@ $emergencyContactsView = views_embed_view('emergency_contacts', 'non_dependant_e
   <?php require_once __DIR__ . '/page_body.tpl.php'; ?>
 
   <div class="container region region-content">
-    <h2>Emergency Contacts</h2>';
+    <h2>Emergency Contacts</h2>
     <?php print $emergencyContactsView; ?>
   </div>
 

--- a/civihr_default_theme/templates/view/views-view-field--emergency-contacts--dependant-emergency-contact--emergency-contact-deletion.tpl.php
+++ b/civihr_default_theme/templates/view/views-view-field--emergency-contacts--dependant-emergency-contact--emergency-contact-deletion.tpl.php
@@ -3,12 +3,12 @@
     class="pointer"
     type="button"
     data-toggle="modal"
-    data-target="#delete-emergency-contact-<?php print $row->id ?>">
+    data-target="#delete-dependents-<?php print $row->id ?>">
     <i class="fa fa-trash text-danger" aria-hidden="true"></i>
   </a>
 
   <!-- Modal -->
-  <div class="modal fade" id="delete-emergency-contact-<?php print $row->id ?>" role="dialog">
+  <div class="modal fade" id="delete-dependents-<?php print $row->id ?>" role="dialog">
     <div class="modal-dialog modal-sm">
       <div class="modal-content">
         <div class="modal-header">
@@ -18,7 +18,7 @@
           <h4 class="modal-title">Confirm Deletion</h4>
         </div>
         <div class="modal-body">
-          Are you sure you want to remove this emergency contact?
+          Are you sure you want to remove this dependent?
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-link text-uppercase" data-dismiss="modal">

--- a/civihr_default_theme/templates/view/views-view-field--emergency-contacts--dependant-emergency-contact--emergency-contact-deletion.tpl.php
+++ b/civihr_default_theme/templates/view/views-view-field--emergency-contacts--dependant-emergency-contact--emergency-contact-deletion.tpl.php
@@ -1,36 +1,3 @@
-<div>
-  <a
-    class="pointer"
-    type="button"
-    data-toggle="modal"
-    data-target="#delete-dependents-<?php print $row->id ?>">
-    <i class="fa fa-trash text-danger" aria-hidden="true"></i>
-  </a>
-
-  <!-- Modal -->
-  <div class="modal fade" id="delete-dependents-<?php print $row->id ?>" role="dialog">
-    <div class="modal-dialog modal-sm">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal">
-            <span aria-hidden="true">&times;</span><span class="sr-only">Close</span>
-          </button>
-          <h4 class="modal-title">Confirm Deletion</h4>
-        </div>
-        <div class="modal-body">
-          Are you sure you want to remove this dependent?
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-link text-uppercase" data-dismiss="modal">
-            Cancel
-          </button>
-          <button
-            class="btn btn-danger text-uppercase"
-            onclick="Drupal.civihr_theme.deleteEmergencyContact(<?php print $row->id ?>); location.reload();">
-            Confirm
-          </button>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+<?php
+// the content is the same, just different template
+require 'views-view-field--emergency-contacts--non-dependant-emergency-contact--emergency_contact_deletion.tpl.php'; ?>

--- a/civihr_default_theme/templates/view/views-view-field--emergency-contacts--non-dependant-emergency-contact--emergency_contact_deletion.tpl.php
+++ b/civihr_default_theme/templates/view/views-view-field--emergency-contacts--non-dependant-emergency-contact--emergency_contact_deletion.tpl.php
@@ -13,7 +13,8 @@
       <div class="modal-content">
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal">
-            <span aria-hidden="true">&times;</span><span class="sr-only">Close</span>
+            <span aria-hidden="true">&times;</span>
+            <span class="sr-only">Close</span>
           </button>
           <h4 class="modal-title">Confirm Deletion</h4>
         </div>
@@ -26,7 +27,7 @@
           </button>
           <button
             class="btn btn-danger text-uppercase"
-            onclick="Drupal.civihr_theme.deleteEmergencyContact(<?php print $row->id ?>); location.reload();">
+            onclick="Drupal.civihr_theme.deleteEmergencyContactAndRefresh(<?php print $row->id ?>);">
             Confirm
           </button>
         </div>

--- a/civihr_default_theme/templates/view/views-view-field--emergency-contacts--non-dependant-emergency-contact--emergency_contact_deletion.tpl.php
+++ b/civihr_default_theme/templates/view/views-view-field--emergency-contacts--non-dependant-emergency-contact--emergency_contact_deletion.tpl.php
@@ -1,5 +1,7 @@
 <div id="bootstrap-theme">
-  <a type="button" data-toggle="modal" data-target="#delete-emergency-contact-<?php print $row->id ?>"><i class="fa fa-trash" aria-hidden="true"></i></a>
+  <a type="button" data-toggle="modal" data-target="#delete-emergency-contact-<?php print $row->id ?>">
+    <i class="fa fa-trash" aria-hidden="true"></i>
+  </a>
 
   <!-- Modal -->
   <div class="modal fade" id="delete-emergency-contact-<?php print $row->id ?>" role="dialog">
@@ -13,10 +15,12 @@
           <p>This cannot be undone</p>
         </div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-link text-uppercase">Cancel</button>
-          <form action="/action_page.php?id=<?php print $row->id ?>" method="get">
-            <input class="btn btn-danger" type="submit" value="Confirm">
-          </form>
+          <button type="button" class="btn btn-link text-uppercase">
+            Cancel
+          </button>
+          <button onclick="Drupal.civihr_theme.deleteEmergencyContact(<?php print $row->id ?>); location.reload();">
+            Confirm
+          </button>
         </div>
       </div>
     </div>

--- a/civihr_default_theme/templates/view/views-view-field--emergency-contacts--non-dependant-emergency-contact--nothing.tpl.php
+++ b/civihr_default_theme/templates/view/views-view-field--emergency-contacts--non-dependant-emergency-contact--nothing.tpl.php
@@ -1,0 +1,24 @@
+<div id="bootstrap-theme">
+  <a type="button" data-toggle="modal" data-target="#delete-emergency-contact-<?php print $row->id ?>"><i class="fa fa-trash" aria-hidden="true"></i></a>
+
+  <!-- Modal -->
+  <div class="modal fade" id="delete-emergency-contact-<?php print $row->id ?>" role="dialog">
+    <div class="modal-dialog modal-sm">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal">&times;</button>
+          <h4 class="modal-title">Confirm Deletion</h4>
+        </div>
+        <div class="modal-body">
+          <p>This cannot be undone</p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-link text-uppercase">Cancel</button>
+          <form action="/action_page.php?id=<?php print $row->id ?>" method="get">
+            <input class="btn btn-danger" type="submit" value="Confirm">
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Overview
As part of this PR(and https://github.com/compucorp/civihr-employee-portal/pull/393), the Delete button is added to the Emergency Contacts and Dependents View.

## Screencast
![2850](https://user-images.githubusercontent.com/5058867/32835452-2c821426-ca2c-11e7-9ed2-c90bbef18a85.gif)

## Technical Details
1. `views-view-field--emergency-contacts--non-dependant-emergency-contact--emergency_contact_deletion.tpl.php` and `views-view-field--emergency-contacts--dependant-emergency-contact--emergency-contact-deletion.tpl.php` added as overrides for the Custom text added in https://github.com/compucorp/civihr-employee-portal/pull/393. Here the markup for the modal is defined.

2. `Drupal.civihr_theme.deleteEmergencyContact ` is defined to call the backend to delete the contacts.

---
