### PR TITLE
PCHR-2851: Add buttons for creating emergency contacts

### DIFF
--- a/civihr_default_theme/templates/page/page--hr-details.tpl.php
+++ b/civihr_default_theme/templates/page/page--hr-details.tpl.php
@@ -10,11 +10,19 @@ $emergencyContactsView = views_embed_view('emergency_contacts', 'non_dependant_e
 
   <div class="container region region-content">
     <h2>Emergency Contacts</h2>
+    <a href="/create-emergency-contact/js/view"
+       class="ctools-use-modal ctools-modal-civihr-custom-style chr_action--icon--edit">
+      Add Emergency Contact
+    </a>
     <?php print $emergencyContactsView; ?>
   </div>
 
   <div class="container region region-content">
     <h2>Dependants</h2>
+    <a href="/create-dependant/js/view"
+       class="ctools-use-modal ctools-modal-civihr-custom-style chr_action--icon--edit">
+      Add Dependant
+    </a>
     <?php print $dependantsView; ?>
   </div>
 


### PR DESCRIPTION
## Overview

To allow the user to create emergency contacts new buttons were added which open modals showing the emergency contact / dependant creation webforms

## Before

There were no buttons to create emergency contacts / dependants on the `hr-details` page.

![image](https://user-images.githubusercontent.com/6374064/33030689-e7c671a6-ce13-11e7-877a-03ad1cff146b.png)

## After

There are buttons to create emergency contacts / dependants on the `hr-details` page.

![image](https://user-images.githubusercontent.com/6374064/33031638-cd71618c-ce16-11e7-92b3-1c678bd7647c.png)

## Notes

This provides the basic markup, styling will be done separately by @deb1990 

---

- [ ] Tests Pass
There are no tests :spoon: 
