### PR TITLE
PCHR-3037: Update HR Admin menu item identifier

### DIFF
--- a/civihr_default_theme/template.php
+++ b/civihr_default_theme/template.php
@@ -841,7 +841,7 @@ function _add_unique_class_to_menu_link(&$link) {
 function _hide_admin_menu_link_to_basic_users(&$link) {
   $adminAccess = user_access("administer CiviCRM");
   $localOptions = $link['#localized_options'];
-  $isAdminLink = isset($localOptions['identifier']) && $localOptions['identifier'] === 'main-menu_civihr-admin:civicrm';
+  $isAdminLink = isset($localOptions['identifier']) && $localOptions['identifier'] === 'main-menu_hr-admin:civicrm';
 
   if ($isAdminLink && !$adminAccess) {
     $link['#attributes']['class'][] = 'hidden';


### PR DESCRIPTION
## Overview
This PR hides the HR Admin menu item for staff roles.

## Before
![dashboard hr17 9000](https://user-images.githubusercontent.com/1642119/34046607-07d23f7e-e184-11e7-92be-be0b34bf6a7e.png)

## After
![dashboard hr17 9000 1](https://user-images.githubusercontent.com/1642119/34046725-58682624-e184-11e7-989e-cd38eec08a75.png)


## Technical Details
The identifier for the HR Admin menu item was updated and needed to be changed in the `_hide_admin_menu_link_to_basic_users` function, which hides the HR Admin menu if the user doesn't have the "administer CiviCRM" permission.

The identifier update and explanation can be found on this PR:
https://github.com/compucorp/civihr-employee-portal/pull/412

Backstop tests on the Report page ran successfully.

---

- [x] Tests Pass
