### PR TITLE
PCHR-3170: Re-add "Customize Welcome Wizard" Link

### DIFF
--- a/civihr_default_theme/template.php
+++ b/civihr_default_theme/template.php
@@ -494,19 +494,25 @@ function _build_cog_menu_markup() {
 function _get_cog_menu_items() {
   $resourceTypeVocabularyID = taxonomy_vocabulary_machine_name_load('hr_resource_type')->vid;
 
+  $options = ['html' => TRUE];
+
   return [
     [
       'permissions' => ["access content overview"],
-      'link' => l(t('Manage HR Resources'), 'admin/content', ['html' => TRUE]),
+      'link' => l(t('Manage HR Resources'), 'admin/content', $options),
     ],
     [
       'permissions' => ["edit terms in {$resourceTypeVocabularyID}"],
-      'link' => l(t('HR Resource Types'), 'hr-resource-types-list', ['html' => TRUE]),
+      'link' => l(t('HR Resource Types'), 'hr-resource-types-list', $options),
       'separator' => TRUE,
     ],
     [
       'permissions' => ["administer users", "access users overview"],
-      'link' => l(t('Manage Users'), 'admin/people', ['html' => TRUE]),
+      'link' => l(t('Manage Users'), 'admin/people', $options),
+    ],
+    [
+      'permissions' => ['customize welcome wizard'],
+      'link' => l(t('Customize Welcome Wizard'), 'customize-onboarding-wizard', $options),
     ],
   ];
 }


### PR DESCRIPTION
## Overview

When merging the changes from menu refactoring into the onboarding branch the cog menu item for "Customize Welcome Wizard" was dropped in a [merge conflict resolution](https://github.com/compucorp/civihr-employee-portal-theme/commit/b5669798a1216615f7ce4d637b7ebefa17995fad#diff-4b16c32fda3f6db9862b392f76668cdeL23). This needs to be re-added.

## Before

The "Customize Welcome Wizard" cog menu item is missing

![image](https://user-images.githubusercontent.com/6374064/34945446-515da590-f9fb-11e7-841d-64e953ba33b4.png)

## After

The "Customize Welcome Wizard" cog menu item is back

![image](https://user-images.githubusercontent.com/6374064/34945512-8e284ab6-f9fb-11e7-9885-d3ec47c7a84c.png)


## Comments

This repository did not have any PHP tests until now, but this PR adds the first PHPUnit test to check that the expected link markup will be returned.

---

- [x] Tests Pass
