### PR TITLE
PCHR-3213: Fix HR Admin identifier

### DIFF
--- a/civihr_default_theme/template.php
+++ b/civihr_default_theme/template.php
@@ -847,7 +847,7 @@ function _add_unique_class_to_menu_link(&$link) {
 function _hide_admin_menu_link_to_basic_users(&$link) {
   $adminAccess = user_access("administer CiviCRM");
   $localOptions = $link['#localized_options'];
-  $isAdminLink = isset($localOptions['identifier']) && $localOptions['identifier'] === 'main-menu_civihr-admin:civicrm';
+  $isAdminLink = isset($localOptions['identifier']) && $localOptions['identifier'] === 'main-menu_hr-admin:civicrm';
 
   if ($isAdminLink && !$adminAccess) {
     $link['#attributes']['class'][] = 'hidden';


### PR DESCRIPTION
On https://github.com/compucorp/civihr-employee-portal-theme/pull/289 the identifier of the "HR Admin" menu item was updated in the function that hides the link on the login page. However, it looks that the `PCHR-3002-changes-to-report-page` branch (where that PR was merged) was rebased at some point this change was lost. This PR adds it again.

**Note**: I've checked all the pull requests merged to `PCHR-3002-changes-to-report-page` after https://github.com/compucorp/civihr-employee-portal-theme/pull/289 was merged and this is the only change that was missing