### PR TITLE
PCHR-3051: Fix Webform Conditional Hiding

### DIFF
--- a/civihr_default_theme/assets/js/civihr_default_theme.script.js
+++ b/civihr_default_theme/assets/js/civihr_default_theme.script.js
@@ -53,7 +53,7 @@
       addVerticalLineInCustomizeOnboardingPage();
       applyCustomSelectOnRadioClick();
       handleWebformCalendar();
-      hideSSNLabelOnCheckboxClick();
+      hideSSNFieldOnSkipCheckboxClick();
       removeTextFromCarouselPager();
       Drupal.civihr_theme.createDragAndDrop('.onboarding_wizard_profile_pic_upload_image input[type="file"]');
       Drupal.civihr_theme.createDragAndDrop('#edit-civihr-onboarding-organization-logo-fid-ajax-wrapper input[type="file"]');
@@ -275,8 +275,8 @@
   /**
    * Hide the SSN Label of Onboarding page when the checkbox is checked
    */
-  function hideSSNLabelOnCheckboxClick () {
-    var ssnCheckbox = $('.onboarding_wizard_payroll_ssin_checkbox input.form-checkbox');
+  function hideSSNFieldOnSkipCheckboxClick () {
+    var ssnCheckbox = $('.onboarding_wizard_payroll_skip_checkbox input.form-checkbox');
     var ssnLabel = $('.onboarding_wizard_payroll_ssin_textfield');
 
     // set initial state of the label, based on checkbox's value

--- a/civihr_default_theme/assets/js/civihr_default_theme.script.js
+++ b/civihr_default_theme/assets/js/civihr_default_theme.script.js
@@ -273,7 +273,7 @@
   }
 
   /**
-   * Hide the SSN Label of Onboarding page when the checkbox is checked
+   * Hide the SSN field of Onboarding page when the radio button is "Add Later"
    */
   function hideSSNFieldOnSkipRadioChange () {
     var skipRadio = $('.onboarding_wizard_payroll_skip_radio input.form-radio');

--- a/civihr_default_theme/assets/js/civihr_default_theme.script.js
+++ b/civihr_default_theme/assets/js/civihr_default_theme.script.js
@@ -53,7 +53,7 @@
       addVerticalLineInCustomizeOnboardingPage();
       applyCustomSelectOnRadioClick();
       handleWebformCalendar();
-      hideSSNFieldOnSkipCheckboxClick();
+      hideSSNFieldOnSkipRadioChange();
       removeTextFromCarouselPager();
       Drupal.civihr_theme.createDragAndDrop('.onboarding_wizard_profile_pic_upload_image input[type="file"]');
       Drupal.civihr_theme.createDragAndDrop('#edit-civihr-onboarding-organization-logo-fid-ajax-wrapper input[type="file"]');
@@ -275,14 +275,15 @@
   /**
    * Hide the SSN Label of Onboarding page when the checkbox is checked
    */
-  function hideSSNFieldOnSkipCheckboxClick () {
-    var ssnCheckbox = $('.onboarding_wizard_payroll_skip_checkbox input.form-checkbox');
-    var ssnLabel = $('.onboarding_wizard_payroll_ssin_textfield');
+  function hideSSNFieldOnSkipRadioChange () {
+    var skipRadio = $('.onboarding_wizard_payroll_skip_radio input.form-radio');
+    var ssnField = $('.onboarding_wizard_payroll_ssin_textfield');
+    var skipStep = 1;
 
-    // set initial state of the label, based on checkbox's value
-    ssnCheckbox.is(':checked') ? ssnLabel.hide() : ssnLabel.show();
-    ssnCheckbox.click(function () {
-      ssnLabel.toggle();
+    // set initial state of the label, based on radio button value
+    skipRadio.val() === skipStep ? ssnField.hide() : ssnField.show();
+    skipRadio.change(function () {
+      ssnField.toggle();
     });
   }
 

--- a/civihr_default_theme/assets/js/civihr_default_theme.script.js
+++ b/civihr_default_theme/assets/js/civihr_default_theme.script.js
@@ -278,10 +278,11 @@
   function hideSSNFieldOnSkipRadioChange () {
     var skipRadio = $('.onboarding_wizard_payroll_skip_radio input.form-radio');
     var ssnField = $('.onboarding_wizard_payroll_ssin_textfield');
-    var skipStep = 1;
+    var addLater = '1';
+    var selected = $('.onboarding_wizard_payroll_skip_radio input.form-radio:checked');
 
     // set initial state of the label, based on radio button value
-    skipRadio.val() === skipStep ? ssnField.hide() : ssnField.show();
+    selected.val() === addLater ? ssnField.hide() : ssnField.show();
     skipRadio.change(function () {
       ssnField.toggle();
     });

--- a/civihr_default_theme/template.php
+++ b/civihr_default_theme/template.php
@@ -741,6 +741,10 @@ function civihr_default_theme_form_apply_bootstrap($fields_structure, $section_w
 
     $wrapperAttr = CRM_Utils_Array::value('#wrapper_attributes', $value, []);
     $wrappperClasses = CRM_Utils_Array::value('class', $wrapperAttr, []);
+
+    // Without this the prefix will not be hidden by conditionals
+    $wrappperClasses[] = 'webform-component--' . str_replace('_', '-', $key);
+
     $wrappperClasses = implode(' ', $wrappperClasses);
     unset($fields_structure[$key]['#wrapper_attributes']); // once is enough
 


### PR DESCRIPTION
## Overview

Webform conditionals allow you to hide / show a field based on the value of another field. However we add a [prefix](https://github.com/compucorp/civihr-employee-portal-theme/blob/9bc4b207f7a7457cf9dbfe4b9a16613dc7f18579/civihr_default_theme/template.php#L752) to the fields that contains the label. This is not hidden as part of the webform conditionals, which leaves just the label visible if a field is hidden. This PR fixes that.

## Before

Webform conditionals would not hide the label for a field if it was hidden by the conditional logic. Also we used a Javascript function to get around this for the NI/SSN field in the onboarding form.

## After

The class that the webform conditionals use is added to the wrapper div. This means that the entire element (including the label) will be hidden if the webform conditional logic defines that it should be.

## Comments

`hideSSNLabelOnCheckboxClick` is no longer necessary because of the fix. However since [two conditionals cannot target the same element](https://www.drupal.org/project/webform/issues/2481043) and the specs define that NI/SSN must be hidden _both_ when the "Skip this step" box is checked _and_ when the "I am applying for NI/SSN" box is checked we need to use a separate Javascript function to handle the hiding of this element. I just repurposed `hideSSNLabelOnCheckboxClick` for this.

---

- [ ] Tests Pass
No tests in this repo
