### PR TITLE
PCHR-3206: Onboarding Menu and Footer updates

### DIFF
--- a/civihr_default_theme/includes/footer.inc
+++ b/civihr_default_theme/includes/footer.inc
@@ -4,7 +4,7 @@
       Powered by CiviHR <?php print get_civihr_version(); ?>.
       CiviHR is openly available under the <a target="_blank" href="http://www.gnu.org/licenses/agpl-3.0.html">GNU AGPL License</a> and can be downloaded from the <a target="_blank" href="https://civihr.org">Project website</a>&nbsp;.
       <div class="footer-logo">
-        <i class="icon-logo-full"></i>
+        <span class="chr_logo chr_logo--full chr_logo--default-size"><i></i></span>
       </div>
       <?php if ($copyright): ?>
         <div class="copyright"><?php print $copyright; ?></div>

--- a/civihr_default_theme/includes/header_basic.inc
+++ b/civihr_default_theme/includes/header_basic.inc
@@ -1,12 +1,4 @@
 <header class="chr_header">
-  <div class="chr_header__corner">
-    <div class="chr_header__nav__toggle">
-      <i class="fa fa-2x fa-navicon"></i>
-    </div>
-    <a href="/dashboard" class="chr_header__logo">
-      <span class="chr_logo"></span>
-    </a>
-  </div>
   <div class="chr_header__logo">
     <span class="chr_logo chr_logo--full"><i></i></span>
   </div>


### PR DESCRIPTION
## Overview
In Onboarding wizard, the Hamburger menu was visible and the CiviHR logo was missing in the Footer. Both the issues are fixed in this PR.

## Before
Hamburger menu
![2018-02-01 at 4 32 pm](https://user-images.githubusercontent.com/5058867/35675288-77fe2bdc-076d-11e8-900e-fc0f74de5aff.png)

CiviHR Logo on Footer
![2018-02-01 at 4 32 pm](https://user-images.githubusercontent.com/5058867/35675309-8c8ccb12-076d-11e8-9f9e-a68010067da4.png)

## After
Hamburger menu
![2018-02-01 at 4 35 pm](https://user-images.githubusercontent.com/5058867/35675423-f4ed22b0-076d-11e8-8167-d1e787ce1591.png)

CiviHR Logo on Footer
![2018-02-01 at 4 36 pm](https://user-images.githubusercontent.com/5058867/35675444-07aa298e-076e-11e8-8b3d-af5e410a970a.png)

## Technical Details
1. In `header_basic.inc` the menu markup has been removed, as the basic version does not need to show it.
2. In `footer.inc` the CiviHR logo was missing which is included.
Note: The `footer.inc` is also used in HR Details page, which also had the same bug, the above fixes that too.

---

