### PR TITLE
PCHR-3347: Modify Manage Users Page Link and Permissions

### DIFF
--- a/civihr_default_theme/template.php
+++ b/civihr_default_theme/template.php
@@ -508,8 +508,8 @@ function _get_cog_menu_items() {
       'separator' => TRUE,
     ],
     [
-      'permissions' => ["administer users", "access users overview"],
-      'link' => l(t('Manage Users'), 'admin/people', $options),
+      'permissions' => ['administer staff accounts'],
+      'link' => l(t('Manage Users'), 'users-list', $options),
     ],
     [
       'permissions' => ['customize welcome wizard'],


### PR DESCRIPTION
## Overview
The Manage users URL on the SSP was previously pointing to `/admin/people`, This PR switches that URL to point to the new Users List view instead and also update the permission for accessing the Link to `administer staff accounts` which is the required permission to access the Users List View.

## Before
- The Manage users URL on the SSP was previously pointing to `/admin/people`
- The permissions to access the Manage Users URL was `administer users` or `access users overview`

## After
- The Manage users URL on the SSP is now pointing to `users-list`
- The permissions to access the Manage Users URL is now `administer staff accounts`

The changes doe not affect tests.
- [ ] Tests Pass
