### PR TITLE
PCHR-3508: Disable auto-zoom on input focus

### DIFF
--- a/civihr_default_theme/template.php
+++ b/civihr_default_theme/template.php
@@ -609,6 +609,18 @@ function civihr_default_theme_file_icon($variables) {
 }
 
 /**
+ * Implements hook_html_head_alter() - alters html head tags.
+ *
+ * Sets viewport "maximum-scale" to 1 to prevent auto zooming on input focus.
+ * @see https://stackoverflow.com/questions/11064237/prevent-iphone-from-zooming-form
+ *
+ * @param object $head_elements
+ */
+function civihr_default_theme_html_head_alter(&$head_elements) {
+  _set_maximum_scale_to_viewport_meta_tag($head_elements);
+}
+
+/**
  * Gets font-awesome class depending on file's mime-type
  * @param $mime
  * @return string
@@ -903,4 +915,31 @@ function _add_sub_menu_to_link(&$link) {
   $link['#localized_options']['attributes']['data-target'] = '#';
 
   return '<ul class="dropdown-menu">' . drupal_render($link['#below']) . '</ul>';
+}
+
+/**
+ * Sets the maximum viewport scale to 1.
+ * @NOTE this still allows users to pinch/zoom with 2 fingers.
+ * @NOTE this function expects that the Meta Viewport tag is already set.
+ *
+ * @param object $head_elements
+ */
+function _set_maximum_scale_to_viewport_meta_tag(&$head_elements) {
+  // Get the meta tag by reference
+  foreach ($head_elements as $tagKey => $tag) {
+    if (isset($tag['#attributes']['name']) && $tag['#attributes']['name'] === 'viewport') {
+      $viewportTagValue = &$head_elements[$tagKey]['#attributes']['content'];
+    }
+  }
+
+  // Filter out "maximum-scale" property if exists
+  $rules = array_filter(preg_split('/\s*,\s*/', $viewportTagValue), function ($rule) {
+    return !preg_match('/^maximum-scale\s*=/i', $rule);
+  });
+
+  // Push new "maximum-scale" property
+  array_push($rules, 'maximum-scale=1');
+
+  // Set updated rules to the tag
+  $viewportTagValue = implode(', ', $rules);
 }


### PR DESCRIPTION
## Overview

This PR fixes viewport auto-zooming on inputs focusing on iOS devices. It still allows users to pinch and zoom with 2 fingers.

## Before

![1](https://user-images.githubusercontent.com/3973243/38414940-d6bfa474-3987-11e8-9e8b-9626c65a79ce.gif)

## After

![2](https://user-images.githubusercontent.com/3973243/38414943-da584ca8-3987-11e8-900a-a581dae6a5cf.gif)

## Technical Details

Please see https://api.drupal.org/api/drupal/modules%21system%21system.api.php/function/hook_html_head_alter/7.x

```php
// Alters head elements (tags)
function civihr_default_theme_html_head_alter(&$head_elements) {
  _set_maximum_scale_to_viewport_meta_tag($head_elements);

function _set_maximum_scale_to_viewport_meta_tag(&$head_elements) {
  // Get the meta tag by reference
  foreach ($head_elements as $tagKey => $tag) {
    if (isset($tag['#attributes']['name']) && $tag['#attributes']['name'] === 'viewport') {
      $viewportTagValue = &$head_elements[$tagKey]['#attributes']['content'];

  // Filter out "maximum-scale" property if exists
  $rules = array_filter(preg_split('/\s*,\s*/', $viewportTagValue), function ($rule) {
    return !preg_match('/^maximum-scale\s*=/i', $rule);

  // Push new "maximum-scale" property
  array_push($rules, 'maximum-scale=1');

  // Set updated rules to the tag
  $viewportTagValue = implode(', ', $rules);
}
```

## Comments

The commit https://github.com/compucorp/civihr-employee-portal-theme/pull/333/commits/45c2f65338f66694c9c3cc0a52ac860c0920b7e2 just reorders private functions and it has one extra line deletion because of the double empty line https://github.com/compucorp/civihr-employee-portal-theme/pull/333/commits/45c2f65338f66694c9c3cc0a52ac860c0920b7e2#diff-f421b1bbc7953a1d262886e0149faffdL537

---

✅Manual Tests - passed
