### PR TITLE
PCHR-3570: Footer Updates

### DIFF
--- a/civihr_default_theme/includes/footer.inc
+++ b/civihr_default_theme/includes/footer.inc
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="text-center">
       Powered by CiviHR <?php print get_civihr_version(); ?>.
-      CiviHR is openly available under the <a target="_blank" href="http://www.gnu.org/licenses/agpl-3.0.html">GNU AGPL License</a> and can be downloaded from the <a target="_blank" href="https://civihr.org">Project website</a>&nbsp;.
+      CiviHR is openly available under Version 3 of the <a target="_blank" href="http://www.gnu.org/licenses/agpl-3.0.html">GNU AGPL License</a> and can be downloaded from <a target="_blank" href="https://civihr.org">www.civihr.org</a>&nbsp;.
       <div class="footer-logo">
         <span class="chr_logo chr_logo--full chr_logo--default-size"><i></i></span>
       </div>

--- a/civihr_default_theme/templates/page/page.tpl.php
+++ b/civihr_default_theme/templates/page/page.tpl.php
@@ -78,7 +78,7 @@ $includesDir = __DIR__ . '/../../includes/';
     <div class="container">
       <div class="text-center">
         Powered by CiviHR <?php print get_civihr_version(); ?>.
-        CiviHR is openly available under the <a target="_blank" href="http://www.gnu.org/licenses/agpl-3.0.html">GNU AGPL License</a> and can be downloaded from the <a target="_blank" href="https://civihr.org">Project website</a>&nbsp;.
+        CiviHR is openly available under Version 3 of the <a target="_blank" href="http://www.gnu.org/licenses/agpl-3.0.html">GNU AGPL License</a> and can be downloaded from <a target="_blank" href="https://civihr.org">www.civihr.org</a>&nbsp;.
         <div class="footer-logo">
           <span class="chr_logo chr_logo--full"><i></i></span>
         </div>


### PR DESCRIPTION
## Overview

The footer text should be updated to show the licence version and the site URL instead of "Project Website".

## Before

The footer was "Powered by CiviHR 1.7.5. CiviHR is openly available under the GNU AGPL License and can be downloaded from the Project website ."

![image](https://user-images.githubusercontent.com/6374064/39296384-af74fcaa-4938-11e8-998d-97d80e897643.png)

## After

The footer is "Powered by CiviHR 1.7.5. CiviHR is openly available under Version 3 of the GNU AGPL License and can be downloaded from www.civihr.org ."

![image](https://user-images.githubusercontent.com/6374064/39296260-54e0f9ba-4938-11e8-9506-4444dbf8e5d4.png)
