### PR TITLE
PCHR-3712: remove primary and secondary menu from user profile edit page

### DIFF
--- a/civihr_default_theme/template.php
+++ b/civihr_default_theme/template.php
@@ -956,3 +956,16 @@ function _set_maximum_scale_to_viewport_meta_tag(&$head_elements) {
   // Set updated rules to the tag
   $viewportTagValue = implode(', ', $rules);
 }
+
+/**
+ * Implements theme_menu_local_tasks().
+ */
+function civihr_default_theme_menu_local_tasks(&$variable) {
+  // Remove primary and secondary tabs from user_profile_form page
+  if (arg(0) === 'user' && is_numeric(arg(1)) && arg(2) === 'edit') {
+    $variables['primary']['#access'] = false;
+    $variables['secondary']['#access'] = false;
+  }
+
+  return radix_menu_local_tasks($variables);
+}


### PR DESCRIPTION
## Description
Remove tabs (primary and secondary links) from the top of the user_profile_form page.

## Before
![image](https://user-images.githubusercontent.com/3916979/41113452-4a73dff8-6a47-11e8-9392-01d8679c1c0d.png)

## After
![image](https://user-images.githubusercontent.com/3916979/41113463-523b06da-6a47-11e8-8f87-fee38d35e587.png)
