### PR TITLE
PCHR-3681: Remove hardcoded paths

### DIFF
--- a/civihr_default_theme/template.php
+++ b/civihr_default_theme/template.php
@@ -368,12 +368,16 @@ function civihr_default_theme_css_alter(&$css) {
     $requiredCSS = [
       'modules/system/system.base.css',
       'modules/system/system.theme.css',
-      'sites/all/modules/civicrm/bower_components/font-awesome/css/font-awesome.css',
-      'sites/all/modules/civihr-contrib-required/fancy_login/css/fancy_login.css',
-      'sites/all/modules/civihr-contrib-required/radix_layouts/radix_layouts.css',
-      'sites/all/themes/civihr_employee_portal_theme/civihr_default_theme/assets/css/civihr_default_theme.style.css',
-      'sites/all/modules/civihr-signup/css/civihr-signup.css'
+      dirname(drupal_get_path('module', 'civicrm')) . '/bower_components/font-awesome/css/font-awesome.css',
+      drupal_get_path('module', 'fancy_login') .  '/css/fancy_login.css',
+      drupal_get_path('module', 'radix_layouts') .  '/radix_layouts.css',
+      drupal_get_path('theme', 'civihr_default_theme') .  '/assets/css/civihr_default_theme.style.css',
     ];
+
+    if (module_exists('civihr_signup')) {
+      $requiredCSS[] = drupal_get_path('module', 'civihr_signup') . '/css/civihr-signup.css';
+    }
+
     foreach (array_keys($css) as $file) {
       $found = false;
       foreach ($requiredCSS as $allowedFile) {
@@ -461,29 +465,38 @@ function civihr_default_theme_js_alter(&$javascript) {
 
   // Welcome page optimization
   if (current_path() == 'welcome-page') {
+    // The CiviCRM Drupal module is actually inside the civicrm folder, this is
+    // why we use dirname here, so that we get the civicrm root folder
+    $civicrmPath = dirname(drupal_get_path('module', 'civicrm'));
+    $jqueryUpdatePath = drupal_get_path('module', 'jquery_update');
+
     $requiredJS = [
       'settings',
       'misc/drupal.js',
-      'sites/all/modules/civihr-contrib-required/jquery_update/replace/jquery/1.8/jquery.min.js',
+      $jqueryUpdatePath . '/replace/jquery/1.8/jquery.min.js',
       'misc/jquery.once.js',
-      'sites/all/modules/civicrm/js/noconflict.js',
-      'sites/all/modules/civihr-custom/civihr_employee_portal/js/scripts.js',
-      'sites/all/modules/civihr-contrib-required/ctools/js/modal.js',
-      'sites/all/modules/civicrm/bower_components/jquery/dist/jquery.js',
-      'sites/all/modules/civicrm/bower_components/jquery/dist/jquery.min.js',
-      'sites/all/modules/civicrm/bower_components/jquery-ui/jquery-ui.js',
-      'sites/all/modules/civicrm/bower_components/jquery-ui/jquery-ui.min.js',
-      'sites/all/modules/civicrm/bower_components/lodash-compat/lodash.js',
-      'sites/all/modules/civicrm/bower_components/lodash-compat/lodash.min.js',
-      'sites/all/modules/civicrm/js/crm.ajax.js',
-      'sites/all/modules/civihr-contrib-required/jquery_update/replace/misc/jquery.form.min.js',
+      $civicrmPath . '/js/noconflict.js',
+      $civicrmPath . '/bower_components/jquery/dist/jquery.js',
+      $civicrmPath . '/bower_components/jquery/dist/jquery.min.js',
+      $civicrmPath . '/bower_components/jquery-ui/jquery-ui.js',
+      $civicrmPath . '/bower_components/jquery-ui/jquery-ui.min.js',
+      $civicrmPath . '/bower_components/lodash-compat/lodash.js',
+      $civicrmPath . '/bower_components/lodash-compat/lodash.min.js',
+      $civicrmPath . '/js/crm.ajax.js',
+      $civicrmPath . '/packages/jquery/plugins/jquery.blockUI.min.js',
+      drupal_get_path('module', 'civihr_employee_portal') . '/js/scripts.js',
+      drupal_get_path('module', 'ctools') . '/js/modal.js',
+      $jqueryUpdatePath . '/replace/misc/jquery.form.min.js',
       'misc/ajax.js',
-      'sites/all/modules/civihr-contrib-required/fancy_login/js/fancy_login.js',
-      'sites/all/themes/civihr_employee_portal_theme/civihr_default_theme/assets/js/radix.modal.js',
-      'sites/all/modules/civicrm/packages/jquery/plugins/jquery.blockUI.min.js',
-      'sites/all/modules/civihr-signup/js/civihr-signup.js',
+      drupal_get_path('module', 'fancy_login') . '/js/fancy_login.js',
+      drupal_get_path('theme', 'civihr_default_theme') . '/assets/js/radix.modal.js',
+      'https://sdk.yoti.com/clients/browser.js',
       'https://use.typekit.net/mhr5yod.js',
     ];
+
+    if (module_exists('civihr_signup')) {
+      $requiredJS[] = drupal_get_path('module', 'civihr_signup') . '/js/civihr_signup.js';
+    }
 
     if (module_exists('yoti')) {
       require_once drupal_get_path('module', 'yoti') . '/YotiHelper.php';

--- a/civihr_default_theme/templates/view/views-view--onboarding-slideshow--page.tpl.php
+++ b/civihr_default_theme/templates/view/views-view--onboarding-slideshow--page.tpl.php
@@ -1,6 +1,7 @@
 <?php
 // default view template
-require DRUPAL_ROOT . '/sites/all/modules/contrib/views/theme/views-view.tpl.php';
+$defaultViewTemplate = drupal_get_path('module', 'views') . '/theme/views-view.tpl.php';
+require DRUPAL_ROOT . "/{$defaultViewTemplate}";
 ?>
 
 


### PR DESCRIPTION
## Overview

A site created with the CiviHR installation profile will have the modules, extensions, and themes located in different folders than sites created with the other installation scripts. This theme uses some resources with some hardcoded paths following the folder structure used in existing sites and these fail to load in a site created with the profile.

## Before

The resources used by the theme fail to load in a site built using the profile.

## After

The resources used by the theme load sucessfully in sites built with the profile and with buildkit/civihr-installer.

## Technical Details

Every Drupal site has a `profiles` folder, where all the profiles are kept. Everything used by the profile (modules, libraries and themes) are kept inside the profile own folder instead of the site's global folder. To better understand the difference, let's consider the `civihr_employee_portal_theme` theme as an example:

In a site created with the existing installation scripts, this theme will be located at `sites/all/themes/civihr_employee_portal_theme`, while in a site created with the profile, it will be located at `profiles/civihr/themes/civihr_employee_portal_theme`.

To fix this issue and make sure the resources will always be loaded no matter where they are located, the hardcoded paths have been removed and the `drupal_get_path()` is used to return the paths for modules and themes.