### PR TITLE
PCHR-4175: Change the Endpoint Used for Deleting Emergency Contacts

### DIFF
--- a/civihr_default_theme/assets/js/civihr_default_theme.script.js
+++ b/civihr_default_theme/assets/js/civihr_default_theme.script.js
@@ -38,8 +38,9 @@
    * @param {String} id
    */
   Drupal.civihr_theme.deleteEmergencyContactAndRefresh = function (id) {
-    CRM.api3('contact', 'deleteemergencycontact', { 'id': id });
-    location.reload();
+    $.get('emergency_contacts/' + parseInt(id) + '/delete', null, function() {
+      location.reload();
+    });
   };
 
   /**


### PR DESCRIPTION
## Overview

We want to send a notification email when emergency contacts are deleted from the SSP. Hooking into this from Drupal is difficult (it's a CiviCRM API request) so we can use a new endpoint to handle both deletion and sending of the notification mail.

## Before

From the SSP, deleting an emergency contact used the CiviHR API endpoint `Contact.deleteemergencycontact`

## After

From the SSP, deleting an emergency contact will use the SSP endpoint `emergency_contacts/{id}/delete` which will both delete the emergency contact and send a notification mail.

## Technical Details

Only CiviCRM admins or users that "own" the emergency contact should be able to delete them.

---

- [?] Tests Pass

No tests
